### PR TITLE
Handle sporadic GitHub download issues

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,7 +47,7 @@ runs:
       run: |
         mkdir ~/osv-detector && cd ~/osv-detector
         echo "Installing osv-detector v$OSVDETECTOR_VERSION ($OSVDETECTOR_BINARY)"
-        curl -fL https://github.com/G-Rath/osv-detector/releases/download/v$OSVDETECTOR_VERSION/$OSVDETECTOR_BINARY --output osv-detector
+        curl --connect-timeout 5 --max-time 5 --retry-delay 0 --retry-max-time 30 --retry-all-errors -fL https://github.com/G-Rath/osv-detector/releases/download/v$OSVDETECTOR_VERSION/$OSVDETECTOR_BINARY --output osv-detector
         chmod +x osv-detector
         sudo ln -s ~/osv-detector/osv-detector /usr/local/bin/osv-detector
       env:


### PR DESCRIPTION
GitHub sometimes run into issues so we can try to handle 404s or 5xx error codes with best effort retries:

--connect-timeout 5 = maximum time for a response until a connection is dropped --max-time 5 = maximum number of tries
--retry-delay 0 = turns off exponential back-off
--retry-max-time 30 = max total time before it's considered failed
--retry-all-errors = retry any error (sledgehammer approach)

Thank you!