### PR TITLE
feat: authenticate API requests with  `GITHUB_TOKEN` to increase rate-limit

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,7 +30,12 @@ runs:
       shell: bash
       if: ${{ ! inputs.osv-detector-version }}
       run: |
-        OSVDETECTOR_VERSION=$(curl -s "https://api.github.com/repos/G-Rath/osv-detector/releases/latest" | perl -nle'print substr($&, 1) while m#"tag_name": "\K[^"]*#g')
+        OSVDETECTOR_VERSION=$(
+          curl -s \
+            --header 'authorization: Bearer ${{ github.token }}' \
+            "https://api.github.com/repos/G-Rath/osv-detector/releases/latest" \
+            | perl -nle'print substr($&, 1) while m#"tag_name": "\K[^"]*#g'
+        )
         echo "OSVDETECTOR_VERSION=$OSVDETECTOR_VERSION" >> $GITHUB_ENV
 
     - name: Determine binary


### PR DESCRIPTION
Going to try this out before actually merging, but in theory this should help avoid hitting rate-limits as authenticated requests are limited to 1000 an hour, instead of 60.